### PR TITLE
fix "notCapableReason" for coldwallet setup

### DIFF
--- a/src/activemasternode.cpp
+++ b/src/activemasternode.cpp
@@ -488,6 +488,7 @@ bool CActiveMasternode::EnableHotColdMasterNode(CTxIn& newVin, CService& newServ
     if(!fMasterNode) return false;
 
     status = MASTERNODE_REMOTELY_ENABLED;
+    notCapableReason = "";	
 
     //The values below are needed for signing dseep messages going forward
     this->vin = newVin;


### PR DESCRIPTION
Masternode started remotly showed: {"notCapableReason" : "Could not find suitable coins!"}.